### PR TITLE
ResourceHolder saving and QoL updates

### DIFF
--- a/src/Controls/ResourceGrid.Designer.cs
+++ b/src/Controls/ResourceGrid.Designer.cs
@@ -71,6 +71,7 @@ namespace ResxTranslator.Controls
             this.dataGridView1.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellDoubleClick);
             this.dataGridView1.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellValueChanged);
             this.dataGridView1.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridView1_EditingControlShowing);
+            this.dataGridView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView1_KeyDown);
             // 
             // ResourceGrid
             // 

--- a/src/Controls/ResourceGrid.Designer.cs
+++ b/src/Controls/ResourceGrid.Designer.cs
@@ -33,10 +33,16 @@ namespace ResxTranslator.Controls
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setToEmptyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.contextMenuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // dataGridView1
@@ -47,31 +53,66 @@ namespace ResxTranslator.Controls
             this.dataGridView1.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dataGridView1.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.Raised;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle11.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle11;
             this.dataGridView1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridView1.Location = new System.Drawing.Point(0, 0);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(0);
             this.dataGridView1.Name = "dataGridView1";
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle12.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle12;
             this.dataGridView1.Size = new System.Drawing.Size(150, 150);
             this.dataGridView1.TabIndex = 3;
+            this.dataGridView1.CellContextMenuStripNeeded += new System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventHandler(this.dataGridView1_CellContextMenuStripNeeded);
             this.dataGridView1.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellDoubleClick);
+            this.dataGridView1.CellMouseUp += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridView1_CellMouseUp);
             this.dataGridView1.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellValueChanged);
             this.dataGridView1.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridView1_EditingControlShowing);
             this.dataGridView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView1_KeyDown);
+            // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyToolStripMenuItem,
+            this.pasteToolStripMenuItem,
+            this.setToEmptyToolStripMenuItem});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(153, 92);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.copyToolStripMenuItem.Text = "Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
+            // 
+            // pasteToolStripMenuItem
+            // 
+            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.pasteToolStripMenuItem.Text = "Paste";
+            this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
+            // 
+            // setToEmptyToolStripMenuItem
+            // 
+            this.setToEmptyToolStripMenuItem.Name = "setToEmptyToolStripMenuItem";
+            this.setToEmptyToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.setToEmptyToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.setToEmptyToolStripMenuItem.Text = "Delete";
+            this.setToEmptyToolStripMenuItem.Click += new System.EventHandler(this.setToEmptyToolStripMenuItem_Click);
             // 
             // ResourceGrid
             // 
@@ -79,6 +120,7 @@ namespace ResxTranslator.Controls
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "ResourceGrid";
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.contextMenuStrip1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -86,5 +128,9 @@ namespace ResxTranslator.Controls
         #endregion
 
         private DataGridView dataGridView1;
+        private ContextMenuStrip contextMenuStrip1;
+        private ToolStripMenuItem copyToolStripMenuItem;
+        private ToolStripMenuItem pasteToolStripMenuItem;
+        private ToolStripMenuItem setToEmptyToolStripMenuItem;
     }
 }

--- a/src/Controls/ResourceGrid.cs
+++ b/src/Controls/ResourceGrid.cs
@@ -237,12 +237,25 @@ namespace ResxTranslator.Controls
             }
         }
 
+        private void DeleteSelection()
+        {
+            foreach (DataGridViewCell cell in dataGridView1.SelectedCells)
+            {
+                if (!cell.ReadOnly)
+                    cell.Value = string.Empty;
+            }
+        }
+
         private void dataGridView1_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Control && e.KeyCode == Keys.V)
             {
                 PasteFromClipboard();
                 e.Handled = true;
+            }
+            else if (e.KeyCode == Keys.Delete)
+            {                
+                DeleteSelection();
             }
         }
     }

--- a/src/Controls/ResourceGrid.cs
+++ b/src/Controls/ResourceGrid.cs
@@ -23,6 +23,7 @@ namespace ResxTranslator.Controls
         };
 
         private ResourceHolder _currentResource;
+        private SearchParams _currentSearch;
 
         public ResourceGrid()
         {
@@ -38,6 +39,16 @@ namespace ResxTranslator.Controls
             {
                 _currentResource = value;
                 ShowResourceInGrid(value);
+            }
+        }
+
+        public SearchParams CurrentSearch
+        {
+            get { return _currentSearch; }
+            set
+            {
+                _currentSearch = value;
+                ApplyConditionalFormatting();
             }
         }
 
@@ -86,6 +97,32 @@ namespace ResxTranslator.Controls
             else
             {
                 r.DefaultCellStyle.ForeColor = dataGridView1.DefaultCellStyle.ForeColor;
+            }
+
+            if (CurrentSearch != null)
+            {
+                ApplyConditionalFormattingFromCurrentSearch(r.Cells[ColNameKey], SearchParams.TargetType.Key);
+
+                ApplyConditionalFormattingFromCurrentSearch(r.Cells[ColNameNoLang], SearchParams.TargetType.Text);
+
+                foreach (var lng in CurrentResource.Languages.Values)
+                {
+                    ApplyConditionalFormattingFromCurrentSearch(r.Cells[lng.LanguageId], SearchParams.TargetType.Text);
+                }
+            }
+        }
+
+        private void ApplyConditionalFormattingFromCurrentSearch(DataGridViewCell cell, SearchParams.TargetType targType)
+        {
+            string matchText = cell.Value as string;
+
+            if (matchText != null && CurrentSearch.Match(targType, matchText))
+            {
+                cell.Style.BackColor = Color.GreenYellow;
+            }
+            else
+            {
+                cell.Style.BackColor = dataGridView1.DefaultCellStyle.BackColor;
             }
         }
 

--- a/src/Controls/ResourceGrid.cs
+++ b/src/Controls/ResourceGrid.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using ResxTranslator.ResourceOperations;
 using ResxTranslator.Windows;
+using System.Text.RegularExpressions;
 
 namespace ResxTranslator.Controls
 {
@@ -189,6 +190,60 @@ namespace ResxTranslator.Controls
             dataGridView1.Columns[ColNameKey].ReadOnly = true;
 
             ApplyConditionalFormatting();
+        }
+
+        private void PasteFromClipboard()
+        {
+            DataGridViewCell currentCell = dataGridView1.CurrentCell;
+            DataObject dataObject = (DataObject)Clipboard.GetDataObject();
+
+            if (dataObject.GetDataPresent(DataFormats.Text) && currentCell != null)
+            {
+                var columns = dataGridView1.Columns.Cast<DataGridViewColumn>().OrderBy(c => c.DisplayIndex)
+                    .Where(c => c.Visible && c.ValueType == typeof(string) &&
+                        c.DisplayIndex >= dataGridView1.Columns[currentCell.ColumnIndex].DisplayIndex);
+
+                string[] rowData = Regex.Split(
+                    dataObject.GetData(DataFormats.Text).ToString().TrimEnd(Environment.NewLine.ToCharArray()), Environment.NewLine);
+
+                var data = rowData.Select(r => r.Split('\t')).ToArray();
+
+                int pasteRows = data.Length;
+                if (currentCell.RowIndex + pasteRows > dataGridView1.RowCount - 1)
+                    pasteRows = dataGridView1.RowCount - currentCell.RowIndex - 1;
+
+                if (data.Min(x => x.Length) != data.Max(x => x.Length))
+                    return;
+
+                int pasteColumns = data[0].Length;
+
+                DataGridViewCell cell;
+
+                int j = 0;
+                foreach (var column in columns)
+                {
+                    for (int i = 0; i < pasteRows; i++)
+                    {
+                        cell = dataGridView1.Rows[i + currentCell.RowIndex].Cells[column.Name];
+                        if (!cell.ReadOnly)
+                            cell.Value = data[i][j];
+                    }
+
+                    j++;
+
+                    if (j >= pasteColumns)
+                        break;
+                }
+            }
+        }
+
+        private void dataGridView1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.V)
+            {
+                PasteFromClipboard();
+                e.Handled = true;
+            }
         }
     }
 }

--- a/src/Controls/ResourceGrid.resx
+++ b/src/Controls/ResourceGrid.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/src/Properties/Settings.Designer.cs
+++ b/src/Properties/Settings.Designer.cs
@@ -170,5 +170,17 @@ namespace ResxTranslator.Properties {
                 this["TranslatableInBrackets"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowNullValuesAsGrayed {
+            get {
+                return ((bool)(this["ShowNullValuesAsGrayed"]));
+            }
+            set {
+                this["ShowNullValuesAsGrayed"] = value;
+            }
+        }
     }
 }

--- a/src/Properties/Settings.settings
+++ b/src/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="TranslatableInBrackets" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ShowNullValuesAsGrayed" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/ResourceOperations/ResourceHolder.cs
+++ b/src/ResourceOperations/ResourceHolder.cs
@@ -175,7 +175,11 @@ namespace ResxTranslator.ResourceOperations
                 var key = (string)dataRow[ResourceGrid.ColNameKey];
 
                 var valueData = dataRow[valueColumnId] == DBNull.Value ? null : dataRow[valueColumnId];
-                var stringValueData = valueData?.ToString() ?? string.Empty;
+
+                if (valueData == null)
+                    continue;
+
+                var stringValueData = valueData.ToString() ?? string.Empty;
 
                 var commentData = dataRow[ResourceGrid.ColNameComment] == DBNull.Value ? null : dataRow[ResourceGrid.ColNameComment];
                 var stringCommentData = commentData?.ToString() ?? string.Empty;

--- a/src/Windows/MainWindow.Designer.cs
+++ b/src/Windows/MainWindow.Designer.cs
@@ -39,15 +39,11 @@ namespace ResxTranslator.Windows
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl2 = new System.Windows.Forms.TabControl();
             this.tabPage3 = new System.Windows.Forms.TabPage();
-            this.resourceTreeView1 = new ResxTranslator.Controls.ResourceTreeView();
             this.tabPage5 = new System.Windows.Forms.TabPage();
-            this.missingTranslationView1 = new ResxTranslator.Controls.MissingTranslationView();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.languageSettings1 = new ResxTranslator.Controls.LanguageSettings();
             this.tabControl3 = new System.Windows.Forms.TabControl();
             this.tabPageEditedResource = new System.Windows.Forms.TabPage();
-            this.resourceGrid1 = new ResxTranslator.Controls.ResourceGrid();
             this.menuStripMain = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -73,12 +69,17 @@ namespace ResxTranslator.Windows
             this.copyDefaultValuesOnLanguageAddToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ignoreEmptyResourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openLastDirectoryOnProgramStartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.licenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resourceTreeView1 = new ResxTranslator.Controls.ResourceTreeView();
+            this.missingTranslationView1 = new ResxTranslator.Controls.MissingTranslationView();
+            this.languageSettings1 = new ResxTranslator.Controls.LanguageSettings();
+            this.resourceGrid1 = new ResxTranslator.Controls.ResourceGrid();
+            this.displayNullValuesAsGrayedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.panelMain.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
@@ -199,15 +200,6 @@ namespace ResxTranslator.Windows
             this.tabPage3.Text = "All resources";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
-            // resourceTreeView1
-            // 
-            this.resourceTreeView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.resourceTreeView1.Location = new System.Drawing.Point(0, 0);
-            this.resourceTreeView1.Margin = new System.Windows.Forms.Padding(0);
-            this.resourceTreeView1.Name = "resourceTreeView1";
-            this.resourceTreeView1.Size = new System.Drawing.Size(238, 286);
-            this.resourceTreeView1.TabIndex = 0;
-            // 
             // tabPage5
             // 
             this.tabPage5.Controls.Add(this.missingTranslationView1);
@@ -218,16 +210,6 @@ namespace ResxTranslator.Windows
             this.tabPage5.TabIndex = 1;
             this.tabPage5.Text = "Missing translations";
             this.tabPage5.UseVisualStyleBackColor = true;
-            // 
-            // missingTranslationView1
-            // 
-            this.missingTranslationView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.missingTranslationView1.Location = new System.Drawing.Point(0, 0);
-            this.missingTranslationView1.Margin = new System.Windows.Forms.Padding(0);
-            this.missingTranslationView1.Name = "missingTranslationView1";
-            this.missingTranslationView1.ResourceLoader = null;
-            this.missingTranslationView1.Size = new System.Drawing.Size(238, 286);
-            this.missingTranslationView1.TabIndex = 0;
             // 
             // tabControl1
             // 
@@ -250,15 +232,6 @@ namespace ResxTranslator.Windows
             this.tabPage1.Text = "Languages";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
-            // languageSettings1
-            // 
-            this.languageSettings1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.languageSettings1.Location = new System.Drawing.Point(0, 0);
-            this.languageSettings1.Margin = new System.Windows.Forms.Padding(0);
-            this.languageSettings1.Name = "languageSettings1";
-            this.languageSettings1.Size = new System.Drawing.Size(238, 123);
-            this.languageSettings1.TabIndex = 0;
-            // 
             // tabControl3
             // 
             this.tabControl3.Controls.Add(this.tabPageEditedResource);
@@ -279,16 +252,6 @@ namespace ResxTranslator.Windows
             this.tabPageEditedResource.TabIndex = 0;
             this.tabPageEditedResource.Text = "Resource editor";
             this.tabPageEditedResource.UseVisualStyleBackColor = true;
-            // 
-            // resourceGrid1
-            // 
-            this.resourceGrid1.CurrentResource = null;
-            this.resourceGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.resourceGrid1.Location = new System.Drawing.Point(0, 0);
-            this.resourceGrid1.Margin = new System.Windows.Forms.Padding(0);
-            this.resourceGrid1.Name = "resourceGrid1";
-            this.resourceGrid1.Size = new System.Drawing.Size(626, 439);
-            this.resourceGrid1.TabIndex = 0;
             // 
             // menuStripMain
             // 
@@ -481,7 +444,8 @@ namespace ResxTranslator.Windows
             this.ignoreEmptyResourcesToolStripMenuItem,
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem,
             this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem,
-            this.openLastDirectoryOnProgramStartToolStripMenuItem});
+            this.openLastDirectoryOnProgramStartToolStripMenuItem,
+            this.displayNullValuesAsGrayedToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.settingsToolStripMenuItem.Text = "&Settings";
@@ -504,6 +468,12 @@ namespace ResxTranslator.Windows
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem.Text = "Do not show resources with no translations";
             // 
+            // markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem
+            // 
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Name = "markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem";
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Text = "Mark as translatable only if the default value is in [ ] brackets";
+            // 
             // openLastDirectoryOnProgramStartToolStripMenuItem
             // 
             this.openLastDirectoryOnProgramStartToolStripMenuItem.Name = "openLastDirectoryOnProgramStartToolStripMenuItem";
@@ -524,29 +494,68 @@ namespace ResxTranslator.Windows
             // 
             this.helpToolStripMenuItem1.Image = global::ResxTranslator.Properties.Resources.Help;
             this.helpToolStripMenuItem1.Name = "helpToolStripMenuItem1";
-            this.helpToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
+            this.helpToolStripMenuItem1.Size = new System.Drawing.Size(139, 22);
             this.helpToolStripMenuItem1.Text = "&Help";
             this.helpToolStripMenuItem1.Click += new System.EventHandler(this.helpToolStripMenuItem1_Click);
             // 
             // licenceToolStripMenuItem
             // 
             this.licenceToolStripMenuItem.Name = "licenceToolStripMenuItem";
-            this.licenceToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.licenceToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
             this.licenceToolStripMenuItem.Text = "View licence";
             this.licenceToolStripMenuItem.Click += new System.EventHandler(this.licenceToolStripMenuItem_Click);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
             this.aboutToolStripMenuItem.Text = "&About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
-            // markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem
+            // resourceTreeView1
             // 
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Name = "markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem";
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Text = "Mark as translatable only if the default value is in [ ] brackets";
+            this.resourceTreeView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resourceTreeView1.Location = new System.Drawing.Point(0, 0);
+            this.resourceTreeView1.Margin = new System.Windows.Forms.Padding(0);
+            this.resourceTreeView1.Name = "resourceTreeView1";
+            this.resourceTreeView1.Size = new System.Drawing.Size(238, 286);
+            this.resourceTreeView1.TabIndex = 0;
+            // 
+            // missingTranslationView1
+            // 
+            this.missingTranslationView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.missingTranslationView1.Location = new System.Drawing.Point(0, 0);
+            this.missingTranslationView1.Margin = new System.Windows.Forms.Padding(0);
+            this.missingTranslationView1.Name = "missingTranslationView1";
+            this.missingTranslationView1.ResourceLoader = null;
+            this.missingTranslationView1.Size = new System.Drawing.Size(238, 286);
+            this.missingTranslationView1.TabIndex = 0;
+            // 
+            // languageSettings1
+            // 
+            this.languageSettings1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.languageSettings1.Location = new System.Drawing.Point(0, 0);
+            this.languageSettings1.Margin = new System.Windows.Forms.Padding(0);
+            this.languageSettings1.Name = "languageSettings1";
+            this.languageSettings1.Size = new System.Drawing.Size(238, 123);
+            this.languageSettings1.TabIndex = 0;
+            // 
+            // resourceGrid1
+            // 
+            this.resourceGrid1.CurrentResource = null;
+            this.resourceGrid1.CurrentSearch = null;
+            this.resourceGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resourceGrid1.Location = new System.Drawing.Point(0, 0);
+            this.resourceGrid1.Margin = new System.Windows.Forms.Padding(0);
+            this.resourceGrid1.Name = "resourceGrid1";
+            this.resourceGrid1.Size = new System.Drawing.Size(626, 439);
+            this.resourceGrid1.TabIndex = 0;
+            // 
+            // displayNullValuesAsGrayedToolStripMenuItem
+            // 
+            this.displayNullValuesAsGrayedToolStripMenuItem.Name = "displayNullValuesAsGrayedToolStripMenuItem";
+            this.displayNullValuesAsGrayedToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
+            this.displayNullValuesAsGrayedToolStripMenuItem.Text = "Display values that will not be saved (null) as grayed";
             // 
             // MainWindow
             // 
@@ -637,6 +646,7 @@ namespace ResxTranslator.Windows
         private ToolStripMenuItem licenceToolStripMenuItem;
         private SplitContainer splitContainer1;
         private ToolStripMenuItem markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem;
+        private ToolStripMenuItem displayNullValuesAsGrayedToolStripMenuItem;
     }
 }
 

--- a/src/Windows/MainWindow.cs
+++ b/src/Windows/MainWindow.cs
@@ -89,6 +89,7 @@ namespace ResxTranslator.Windows
             {
                 _currentSearch = value;
                 resourceTreeView1.ExecuteFindInNodes(value);
+                resourceGrid1.CurrentSearch = _currentSearch;
             }
         }
 

--- a/src/Windows/MainWindow.cs
+++ b/src/Windows/MainWindow.cs
@@ -71,11 +71,15 @@ namespace ResxTranslator.Windows
                 settings => settings.HideNontranslatedResources, this);
             Settings.Binder.BindControl(markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem,
                 settings => settings.TranslatableInBrackets, this);
+            Settings.Binder.BindControl(displayNullValuesAsGrayedToolStripMenuItem,
+                settings => settings.ShowNullValuesAsGrayed, this);
 
             Settings.Binder.Subscribe((sender, args) => ResourceLoader.HideEmptyResources = args.NewValue,
                 settings => settings.HideEmptyResources, this);
             Settings.Binder.Subscribe((sender, args) => ResourceLoader.HideNontranslatedResources = args.NewValue,
                 settings => settings.HideNontranslatedResources, this);
+            Settings.Binder.Subscribe((sender, args) => resourceGrid1.ShowNullValuesAsGrayed = args.NewValue,
+                settings => settings.ShowNullValuesAsGrayed, this);
 
             Settings.Binder.SendUpdates(this);
 

--- a/src/app.config
+++ b/src/app.config
@@ -67,6 +67,9 @@
       <setting name="TranslatableInBrackets" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ShowNullValuesAsGrayed" serializeAs="String">
+        <value>False</value>
+      </setting>
     </ResxTranslator.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
Updated ResourceHolder to _not_ save null values as empty strings. Currently if you save a resource it will save null values as empty strings. This is an issue because it prevents applications to default to the NoLanguageValue and will save all previous "missing" values as empty strings. With this I also added an option for cells to appear grayed when value is null to signify values that will not be saved.

Added som quality of life functionality: search highlighting on cells and copy/paste/delete selection