### PR TITLE
ResourceHolder saving, Assembly loading and QoL updates

### DIFF
--- a/src/Controls/ResourceGrid.Designer.cs
+++ b/src/Controls/ResourceGrid.Designer.cs
@@ -71,6 +71,7 @@ namespace ResxTranslator.Controls
             this.dataGridView1.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellDoubleClick);
             this.dataGridView1.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellValueChanged);
             this.dataGridView1.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridView1_EditingControlShowing);
+            this.dataGridView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView1_KeyDown);
             // 
             // ResourceGrid
             // 

--- a/src/Controls/ResourceGrid.Designer.cs
+++ b/src/Controls/ResourceGrid.Designer.cs
@@ -33,10 +33,16 @@ namespace ResxTranslator.Controls
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setToEmptyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.contextMenuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // dataGridView1
@@ -47,31 +53,66 @@ namespace ResxTranslator.Controls
             this.dataGridView1.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dataGridView1.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.Raised;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle11.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle11;
             this.dataGridView1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridView1.Location = new System.Drawing.Point(0, 0);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(0);
             this.dataGridView1.Name = "dataGridView1";
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle12.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle12;
             this.dataGridView1.Size = new System.Drawing.Size(150, 150);
             this.dataGridView1.TabIndex = 3;
+            this.dataGridView1.CellContextMenuStripNeeded += new System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventHandler(this.dataGridView1_CellContextMenuStripNeeded);
             this.dataGridView1.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellDoubleClick);
+            this.dataGridView1.CellMouseUp += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridView1_CellMouseUp);
             this.dataGridView1.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellValueChanged);
             this.dataGridView1.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridView1_EditingControlShowing);
             this.dataGridView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView1_KeyDown);
+            // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyToolStripMenuItem,
+            this.pasteToolStripMenuItem,
+            this.setToEmptyToolStripMenuItem});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(153, 92);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.copyToolStripMenuItem.Text = "Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
+            // 
+            // pasteToolStripMenuItem
+            // 
+            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.pasteToolStripMenuItem.Text = "Paste";
+            this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
+            // 
+            // setToEmptyToolStripMenuItem
+            // 
+            this.setToEmptyToolStripMenuItem.Name = "setToEmptyToolStripMenuItem";
+            this.setToEmptyToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.setToEmptyToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.setToEmptyToolStripMenuItem.Text = "Delete";
+            this.setToEmptyToolStripMenuItem.Click += new System.EventHandler(this.setToEmptyToolStripMenuItem_Click);
             // 
             // ResourceGrid
             // 
@@ -79,6 +120,7 @@ namespace ResxTranslator.Controls
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "ResourceGrid";
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.contextMenuStrip1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -86,5 +128,9 @@ namespace ResxTranslator.Controls
         #endregion
 
         private DataGridView dataGridView1;
+        private ContextMenuStrip contextMenuStrip1;
+        private ToolStripMenuItem copyToolStripMenuItem;
+        private ToolStripMenuItem pasteToolStripMenuItem;
+        private ToolStripMenuItem setToEmptyToolStripMenuItem;
     }
 }

--- a/src/Controls/ResourceGrid.cs
+++ b/src/Controls/ResourceGrid.cs
@@ -237,12 +237,25 @@ namespace ResxTranslator.Controls
             }
         }
 
+        private void DeleteSelection()
+        {
+            foreach (DataGridViewCell cell in dataGridView1.SelectedCells)
+            {
+                if (!cell.ReadOnly)
+                    cell.Value = string.Empty;
+            }
+        }
+
         private void dataGridView1_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Control && e.KeyCode == Keys.V)
             {
                 PasteFromClipboard();
                 e.Handled = true;
+            }
+            else if (e.KeyCode == Keys.Delete)
+            {                
+                DeleteSelection();
             }
         }
     }

--- a/src/Controls/ResourceGrid.cs
+++ b/src/Controls/ResourceGrid.cs
@@ -23,6 +23,7 @@ namespace ResxTranslator.Controls
         };
 
         private ResourceHolder _currentResource;
+        private SearchParams _currentSearch;
 
         public ResourceGrid()
         {
@@ -38,6 +39,16 @@ namespace ResxTranslator.Controls
             {
                 _currentResource = value;
                 ShowResourceInGrid(value);
+            }
+        }
+
+        public SearchParams CurrentSearch
+        {
+            get { return _currentSearch; }
+            set
+            {
+                _currentSearch = value;
+                ApplyConditionalFormatting();
             }
         }
 
@@ -86,6 +97,32 @@ namespace ResxTranslator.Controls
             else
             {
                 r.DefaultCellStyle.ForeColor = dataGridView1.DefaultCellStyle.ForeColor;
+            }
+
+            if (CurrentSearch != null)
+            {
+                ApplyConditionalFormattingFromCurrentSearch(r.Cells[ColNameKey], SearchParams.TargetType.Key);
+
+                ApplyConditionalFormattingFromCurrentSearch(r.Cells[ColNameNoLang], SearchParams.TargetType.Text);
+
+                foreach (var lng in CurrentResource.Languages.Values)
+                {
+                    ApplyConditionalFormattingFromCurrentSearch(r.Cells[lng.LanguageId], SearchParams.TargetType.Text);
+                }
+            }
+        }
+
+        private void ApplyConditionalFormattingFromCurrentSearch(DataGridViewCell cell, SearchParams.TargetType targType)
+        {
+            string matchText = cell.Value as string;
+
+            if (matchText != null && CurrentSearch.Match(targType, matchText))
+            {
+                cell.Style.BackColor = Color.GreenYellow;
+            }
+            else
+            {
+                cell.Style.BackColor = dataGridView1.DefaultCellStyle.BackColor;
             }
         }
 

--- a/src/Controls/ResourceGrid.cs
+++ b/src/Controls/ResourceGrid.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using ResxTranslator.ResourceOperations;
 using ResxTranslator.Windows;
+using System.Text.RegularExpressions;
 
 namespace ResxTranslator.Controls
 {
@@ -189,6 +190,60 @@ namespace ResxTranslator.Controls
             dataGridView1.Columns[ColNameKey].ReadOnly = true;
 
             ApplyConditionalFormatting();
+        }
+
+        private void PasteFromClipboard()
+        {
+            DataGridViewCell currentCell = dataGridView1.CurrentCell;
+            DataObject dataObject = (DataObject)Clipboard.GetDataObject();
+
+            if (dataObject.GetDataPresent(DataFormats.Text) && currentCell != null)
+            {
+                var columns = dataGridView1.Columns.Cast<DataGridViewColumn>().OrderBy(c => c.DisplayIndex)
+                    .Where(c => c.Visible && c.ValueType == typeof(string) &&
+                        c.DisplayIndex >= dataGridView1.Columns[currentCell.ColumnIndex].DisplayIndex);
+
+                string[] rowData = Regex.Split(
+                    dataObject.GetData(DataFormats.Text).ToString().TrimEnd(Environment.NewLine.ToCharArray()), Environment.NewLine);
+
+                var data = rowData.Select(r => r.Split('\t')).ToArray();
+
+                int pasteRows = data.Length;
+                if (currentCell.RowIndex + pasteRows > dataGridView1.RowCount - 1)
+                    pasteRows = dataGridView1.RowCount - currentCell.RowIndex - 1;
+
+                if (data.Min(x => x.Length) != data.Max(x => x.Length))
+                    return;
+
+                int pasteColumns = data[0].Length;
+
+                DataGridViewCell cell;
+
+                int j = 0;
+                foreach (var column in columns)
+                {
+                    for (int i = 0; i < pasteRows; i++)
+                    {
+                        cell = dataGridView1.Rows[i + currentCell.RowIndex].Cells[column.Name];
+                        if (!cell.ReadOnly)
+                            cell.Value = data[i][j];
+                    }
+
+                    j++;
+
+                    if (j >= pasteColumns)
+                        break;
+                }
+            }
+        }
+
+        private void dataGridView1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.V)
+            {
+                PasteFromClipboard();
+                e.Handled = true;
+            }
         }
     }
 }

--- a/src/Controls/ResourceGrid.resx
+++ b/src/Controls/ResourceGrid.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/src/Properties/Settings.Designer.cs
+++ b/src/Properties/Settings.Designer.cs
@@ -170,5 +170,17 @@ namespace ResxTranslator.Properties {
                 this["TranslatableInBrackets"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowNullValuesAsGrayed {
+            get {
+                return ((bool)(this["ShowNullValuesAsGrayed"]));
+            }
+            set {
+                this["ShowNullValuesAsGrayed"] = value;
+            }
+        }
     }
 }

--- a/src/Properties/Settings.Designer.cs
+++ b/src/Properties/Settings.Designer.cs
@@ -182,5 +182,17 @@ namespace ResxTranslator.Properties {
                 this["ShowNullValuesAsGrayed"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string[] ReferencePaths {
+            get {
+                return ((string[])(this["ReferencePaths"]));
+            }
+            set {
+                this["ReferencePaths"] = value;
+            }
+        }
     }
 }

--- a/src/Properties/Settings.settings
+++ b/src/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="TranslatableInBrackets" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ShowNullValuesAsGrayed" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/Properties/Settings.settings
+++ b/src/Properties/Settings.settings
@@ -38,5 +38,8 @@
     <Setting Name="ShowNullValuesAsGrayed" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ReferencePaths" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/ResourceOperations/ResourceHolder.cs
+++ b/src/ResourceOperations/ResourceHolder.cs
@@ -175,11 +175,7 @@ namespace ResxTranslator.ResourceOperations
                 var key = (string)dataRow[ResourceGrid.ColNameKey];
 
                 var valueData = dataRow[valueColumnId] == DBNull.Value ? null : dataRow[valueColumnId];
-
-                if (valueData == null)
-                    continue;
-
-                var stringValueData = valueData.ToString() ?? string.Empty;
+                var stringValueData = valueData?.ToString() ?? string.Empty;
 
                 var commentData = dataRow[ResourceGrid.ColNameComment] == DBNull.Value ? null : dataRow[ResourceGrid.ColNameComment];
                 var stringCommentData = commentData?.ToString() ?? string.Empty;
@@ -191,9 +187,15 @@ namespace ResxTranslator.ResourceOperations
                         .Equals(stringValueData, StringComparison.InvariantCulture))
                         continue;
 
-                    // BUG: Maybe actually delete the resource if stringData is empty?
-                    // BUG: Is comment disabled by null or empty str?
-                    originalResources[key] = new ResXDataNode(originalResources[key].Name, stringValueData) { Comment = stringCommentData };
+                    ResXDataNode originalDataNode;
+                    if (originalResources.TryGetValue(key, out originalDataNode) && valueData == null)
+                    {
+                        originalResources.Remove(key);
+                    }
+                    else
+                    {
+                        originalResources[key] = new ResXDataNode(originalDataNode.Name, stringValueData) { Comment = stringCommentData };
+                    }
                     wasModified = true;
                 }
                 else

--- a/src/ResourceOperations/ResourceHolder.cs
+++ b/src/ResourceOperations/ResourceHolder.cs
@@ -124,8 +124,12 @@ namespace ResxTranslator.ResourceOperations
         {
             // Read the entire resource file to a buffer
             var originalMetadatas = new Dictionary<string, object>();
+
             using (var reader = new ResXResourceReader(filename))
             {
+                // Set base path so that relative paths work
+                reader.BasePath = Path.GetDirectoryName(filename);
+
                 // If UseResXDataNodes == true before you call GetMetadataEnumerator, no resource nodes are retrieved
                 var metadataEnumerator = reader.GetMetadataEnumerator();
                 while (metadataEnumerator.MoveNext())

--- a/src/ResourceOperations/ResourceHolder.cs
+++ b/src/ResourceOperations/ResourceHolder.cs
@@ -126,7 +126,8 @@ namespace ResxTranslator.ResourceOperations
             // Read the entire resource file to a buffer
             var originalMetadatas = new Dictionary<string, object>();
 
-            using (var reader = new ResXResourceReader(filename, AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName()).ToArray()))
+            using (var reader = new ResXResourceReader(filename, 
+                AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName()).ToArray()))
             {
                 // Set base path so that relative paths work
                 reader.BasePath = Path.GetDirectoryName(filename);

--- a/src/ResourceOperations/ResourceHolder.cs
+++ b/src/ResourceOperations/ResourceHolder.cs
@@ -175,7 +175,11 @@ namespace ResxTranslator.ResourceOperations
                 var key = (string)dataRow[ResourceGrid.ColNameKey];
 
                 var valueData = dataRow[valueColumnId] == DBNull.Value ? null : dataRow[valueColumnId];
-                var stringValueData = valueData?.ToString() ?? string.Empty;
+
+                if (valueData == null)
+                    continue;
+
+                var stringValueData = valueData.ToString() ?? string.Empty;
 
                 var commentData = dataRow[ResourceGrid.ColNameComment] == DBNull.Value ? null : dataRow[ResourceGrid.ColNameComment];
                 var stringCommentData = commentData?.ToString() ?? string.Empty;

--- a/src/ResourceOperations/ResourceHolder.cs
+++ b/src/ResourceOperations/ResourceHolder.cs
@@ -8,6 +8,7 @@ using System.Resources;
 using ResxTranslator.Controls;
 using ResxTranslator.Properties;
 using ResxTranslator.Tools;
+using System.Reflection;
 
 namespace ResxTranslator.ResourceOperations
 {
@@ -125,7 +126,7 @@ namespace ResxTranslator.ResourceOperations
             // Read the entire resource file to a buffer
             var originalMetadatas = new Dictionary<string, object>();
 
-            using (var reader = new ResXResourceReader(filename))
+            using (var reader = new ResXResourceReader(filename, AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName()).ToArray()))
             {
                 // Set base path so that relative paths work
                 reader.BasePath = Path.GetDirectoryName(filename);

--- a/src/ResourceOperations/ResourceLoader.cs
+++ b/src/ResourceOperations/ResourceLoader.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;

--- a/src/ResxTranslator.csproj
+++ b/src/ResxTranslator.csproj
@@ -128,6 +128,9 @@
     <EmbeddedResource Include="Windows\AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Windows\EditReferencePaths.resx">
+      <DependentUpon>EditReferencePaths.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Windows\AddResourceKeyWindow.resx">
       <DependentUpon>AddResourceKeyWindow.cs</DependentUpon>
     </EmbeddedResource>
@@ -178,6 +181,12 @@
     </Compile>
     <Compile Include="Windows\AboutBox.Designer.cs">
       <DependentUpon>AboutBox.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\EditReferencePaths.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Windows\EditReferencePaths.Designer.cs">
+      <DependentUpon>EditReferencePaths.cs</DependentUpon>
     </Compile>
     <Compile Include="Windows\AddResourceKeyWindow.cs">
       <SubType>Form</SubType>

--- a/src/Windows/EditReferencePaths.Designer.cs
+++ b/src/Windows/EditReferencePaths.Designer.cs
@@ -1,0 +1,164 @@
+﻿namespace ResxTranslator.Windows
+{
+    partial class EditReferencePaths
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.buttonAdd = new System.Windows.Forms.Button();
+            this.buttonBrowse = new System.Windows.Forms.Button();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.buttonRemove = new System.Windows.Forms.Button();
+            this.buttonClose = new System.Windows.Forms.Button();
+            this.listBox1 = new System.Windows.Forms.ListBox();
+            this.panel1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.tableLayoutPanel1);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panel1.Location = new System.Drawing.Point(5, 263);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(552, 62);
+            this.panel1.TabIndex = 0;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 4;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 82F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 45F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 82F));
+            this.tableLayoutPanel1.Controls.Add(this.buttonBrowse, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.textBox1, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.buttonAdd, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.buttonClose, 3, 1);
+            this.tableLayoutPanel1.Controls.Add(this.buttonRemove, 3, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(552, 62);
+            this.tableLayoutPanel1.TabIndex = 4;
+            // 
+            // buttonAdd
+            // 
+            this.buttonAdd.Location = new System.Drawing.Point(3, 3);
+            this.buttonAdd.Name = "buttonAdd";
+            this.buttonAdd.Size = new System.Drawing.Size(76, 25);
+            this.buttonAdd.TabIndex = 0;
+            this.buttonAdd.Text = "Add Folder";
+            this.buttonAdd.UseVisualStyleBackColor = true;
+            this.buttonAdd.Click += new System.EventHandler(this.buttonAdd_Click);
+            // 
+            // buttonBrowse
+            // 
+            this.buttonBrowse.Location = new System.Drawing.Point(428, 3);
+            this.buttonBrowse.Name = "buttonBrowse";
+            this.buttonBrowse.Size = new System.Drawing.Size(25, 25);
+            this.buttonBrowse.TabIndex = 3;
+            this.buttonBrowse.Text = "...";
+            this.buttonBrowse.UseVisualStyleBackColor = true;
+            this.buttonBrowse.Click += new System.EventHandler(this.buttonBrowse_Click);
+            // 
+            // textBox1
+            // 
+            this.textBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox1.Location = new System.Drawing.Point(85, 6);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(3, 6, 3, 3);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(337, 20);
+            this.textBox1.TabIndex = 2;
+            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            // 
+            // buttonRemove
+            // 
+            this.buttonRemove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonRemove.Location = new System.Drawing.Point(473, 3);
+            this.buttonRemove.Name = "buttonRemove";
+            this.buttonRemove.Size = new System.Drawing.Size(76, 25);
+            this.buttonRemove.TabIndex = 1;
+            this.buttonRemove.Text = "Remove";
+            this.buttonRemove.UseVisualStyleBackColor = true;
+            this.buttonRemove.Click += new System.EventHandler(this.buttonRemove_Click);
+            // 
+            // buttonClose
+            // 
+            this.buttonClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonClose.Location = new System.Drawing.Point(473, 35);
+            this.buttonClose.Name = "buttonClose";
+            this.buttonClose.Size = new System.Drawing.Size(76, 24);
+            this.buttonClose.TabIndex = 4;
+            this.buttonClose.Text = "Close";
+            this.buttonClose.UseVisualStyleBackColor = true;
+            // 
+            // listBox1
+            // 
+            this.listBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listBox1.FormattingEnabled = true;
+            this.listBox1.Location = new System.Drawing.Point(5, 5);
+            this.listBox1.Name = "listBox1";
+            this.listBox1.Size = new System.Drawing.Size(552, 258);
+            this.listBox1.TabIndex = 1;
+            this.listBox1.SelectedIndexChanged += new System.EventHandler(this.listBox1_SelectedIndexChanged);
+            // 
+            // EditReferencePaths
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.buttonClose;
+            this.ClientSize = new System.Drawing.Size(562, 330);
+            this.Controls.Add(this.listBox1);
+            this.Controls.Add(this.panel1);
+            this.Name = "EditReferencePaths";
+            this.Padding = new System.Windows.Forms.Padding(5);
+            this.Text = "Reference Paths";
+            this.panel1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Button buttonRemove;
+        private System.Windows.Forms.Button buttonAdd;
+        private System.Windows.Forms.ListBox listBox1;
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.Button buttonBrowse;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Button buttonClose;
+    }
+}

--- a/src/Windows/EditReferencePaths.Designer.cs
+++ b/src/Windows/EditReferencePaths.Designer.cs
@@ -30,11 +30,11 @@
         {
             this.panel1 = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.buttonAdd = new System.Windows.Forms.Button();
             this.buttonBrowse = new System.Windows.Forms.Button();
             this.textBox1 = new System.Windows.Forms.TextBox();
-            this.buttonRemove = new System.Windows.Forms.Button();
+            this.buttonAdd = new System.Windows.Forms.Button();
             this.buttonClose = new System.Windows.Forms.Button();
+            this.buttonRemove = new System.Windows.Forms.Button();
             this.listBox1 = new System.Windows.Forms.ListBox();
             this.panel1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -70,16 +70,6 @@
             this.tableLayoutPanel1.Size = new System.Drawing.Size(552, 62);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
-            // buttonAdd
-            // 
-            this.buttonAdd.Location = new System.Drawing.Point(3, 3);
-            this.buttonAdd.Name = "buttonAdd";
-            this.buttonAdd.Size = new System.Drawing.Size(76, 25);
-            this.buttonAdd.TabIndex = 0;
-            this.buttonAdd.Text = "Add Folder";
-            this.buttonAdd.UseVisualStyleBackColor = true;
-            this.buttonAdd.Click += new System.EventHandler(this.buttonAdd_Click);
-            // 
             // buttonBrowse
             // 
             this.buttonBrowse.Location = new System.Drawing.Point(428, 3);
@@ -100,16 +90,15 @@
             this.textBox1.TabIndex = 2;
             this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
             // 
-            // buttonRemove
+            // buttonAdd
             // 
-            this.buttonRemove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonRemove.Location = new System.Drawing.Point(473, 3);
-            this.buttonRemove.Name = "buttonRemove";
-            this.buttonRemove.Size = new System.Drawing.Size(76, 25);
-            this.buttonRemove.TabIndex = 1;
-            this.buttonRemove.Text = "Remove";
-            this.buttonRemove.UseVisualStyleBackColor = true;
-            this.buttonRemove.Click += new System.EventHandler(this.buttonRemove_Click);
+            this.buttonAdd.Location = new System.Drawing.Point(3, 3);
+            this.buttonAdd.Name = "buttonAdd";
+            this.buttonAdd.Size = new System.Drawing.Size(76, 25);
+            this.buttonAdd.TabIndex = 0;
+            this.buttonAdd.Text = "Add Folder";
+            this.buttonAdd.UseVisualStyleBackColor = true;
+            this.buttonAdd.Click += new System.EventHandler(this.buttonAdd_Click);
             // 
             // buttonClose
             // 
@@ -121,6 +110,17 @@
             this.buttonClose.TabIndex = 4;
             this.buttonClose.Text = "Close";
             this.buttonClose.UseVisualStyleBackColor = true;
+            // 
+            // buttonRemove
+            // 
+            this.buttonRemove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonRemove.Location = new System.Drawing.Point(473, 3);
+            this.buttonRemove.Name = "buttonRemove";
+            this.buttonRemove.Size = new System.Drawing.Size(76, 25);
+            this.buttonRemove.TabIndex = 1;
+            this.buttonRemove.Text = "Remove";
+            this.buttonRemove.UseVisualStyleBackColor = true;
+            this.buttonRemove.Click += new System.EventHandler(this.buttonRemove_Click);
             // 
             // listBox1
             // 

--- a/src/Windows/EditReferencePaths.cs
+++ b/src/Windows/EditReferencePaths.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using System.IO;
+
+namespace ResxTranslator.Windows
+{
+    public partial class EditReferencePaths : Form
+    {
+        public string[] ReferencePaths
+        {
+            get { return listBox1.Items.Cast<string>().ToArray(); }
+        }
+
+        public EditReferencePaths(string[] paths)
+        {
+            InitializeComponent();
+
+            if (paths != null)
+                listBox1.Items.AddRange(paths);
+            
+            buttonRemove.Enabled = false;
+            buttonAdd.Enabled = false;
+        }
+
+        private void buttonAdd_Click(object sender, EventArgs e)
+        {
+            string dir = textBox1.Text;
+            if (Directory.Exists(dir))
+            {
+                listBox1.Items.Add(dir);
+            }
+            else
+            {
+                MessageBox.Show("The specified directory is not valid or does not exist.");
+            }
+        }
+
+        private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            buttonRemove.Enabled = listBox1.SelectedIndex != -1;
+        }
+
+        private void textBox1_TextChanged(object sender, EventArgs e)
+        {
+            buttonAdd.Enabled = !string.IsNullOrEmpty(textBox1.Text);
+        }
+
+        private void buttonRemove_Click(object sender, EventArgs e)
+        {
+            int index = listBox1.SelectedIndex;
+            if (index != -1)
+            {
+                listBox1.Items.RemoveAt(index);
+            }
+        }
+
+        private void buttonBrowse_Click(object sender, EventArgs e)
+        {
+            using (var dialog = new FolderBrowserDialog())
+            {
+                if (dialog.ShowDialog() == DialogResult.OK)
+                {
+                    textBox1.Text = dialog.SelectedPath;
+                }
+            }
+        }
+    }
+}

--- a/src/Windows/EditReferencePaths.cs
+++ b/src/Windows/EditReferencePaths.cs
@@ -12,6 +12,17 @@ namespace ResxTranslator.Windows
 {
     public partial class EditReferencePaths : Form
     {
+        public static string[] ShowDialog(Form owner, string[] referencePaths)
+        {
+            using (var window = new EditReferencePaths(referencePaths))
+            {
+                window.Icon = owner.Icon;
+                window.StartPosition = FormStartPosition.CenterParent;
+                window.ShowDialog();
+                return window.ReferencePaths;
+            }
+        }
+
         public string[] ReferencePaths
         {
             get { return listBox1.Items.Cast<string>().ToArray(); }

--- a/src/Windows/EditReferencePaths.resx
+++ b/src/Windows/EditReferencePaths.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Windows/MainWindow.Designer.cs
+++ b/src/Windows/MainWindow.Designer.cs
@@ -39,11 +39,15 @@ namespace ResxTranslator.Windows
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl2 = new System.Windows.Forms.TabControl();
             this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.resourceTreeView1 = new ResxTranslator.Controls.ResourceTreeView();
             this.tabPage5 = new System.Windows.Forms.TabPage();
+            this.missingTranslationView1 = new ResxTranslator.Controls.MissingTranslationView();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.languageSettings1 = new ResxTranslator.Controls.LanguageSettings();
             this.tabControl3 = new System.Windows.Forms.TabControl();
             this.tabPageEditedResource = new System.Windows.Forms.TabPage();
+            this.resourceGrid1 = new ResxTranslator.Controls.ResourceGrid();
             this.menuStripMain = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -71,15 +75,12 @@ namespace ResxTranslator.Windows
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openLastDirectoryOnProgramStartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.displayNullValuesAsGrayedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setReferencePathsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.licenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resourceTreeView1 = new ResxTranslator.Controls.ResourceTreeView();
-            this.missingTranslationView1 = new ResxTranslator.Controls.MissingTranslationView();
-            this.languageSettings1 = new ResxTranslator.Controls.LanguageSettings();
-            this.resourceGrid1 = new ResxTranslator.Controls.ResourceGrid();
-            this.displayNullValuesAsGrayedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.panelMain.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
@@ -200,6 +201,15 @@ namespace ResxTranslator.Windows
             this.tabPage3.Text = "All resources";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
+            // resourceTreeView1
+            // 
+            this.resourceTreeView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resourceTreeView1.Location = new System.Drawing.Point(0, 0);
+            this.resourceTreeView1.Margin = new System.Windows.Forms.Padding(0);
+            this.resourceTreeView1.Name = "resourceTreeView1";
+            this.resourceTreeView1.Size = new System.Drawing.Size(238, 286);
+            this.resourceTreeView1.TabIndex = 0;
+            // 
             // tabPage5
             // 
             this.tabPage5.Controls.Add(this.missingTranslationView1);
@@ -210,6 +220,16 @@ namespace ResxTranslator.Windows
             this.tabPage5.TabIndex = 1;
             this.tabPage5.Text = "Missing translations";
             this.tabPage5.UseVisualStyleBackColor = true;
+            // 
+            // missingTranslationView1
+            // 
+            this.missingTranslationView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.missingTranslationView1.Location = new System.Drawing.Point(0, 0);
+            this.missingTranslationView1.Margin = new System.Windows.Forms.Padding(0);
+            this.missingTranslationView1.Name = "missingTranslationView1";
+            this.missingTranslationView1.ResourceLoader = null;
+            this.missingTranslationView1.Size = new System.Drawing.Size(238, 286);
+            this.missingTranslationView1.TabIndex = 0;
             // 
             // tabControl1
             // 
@@ -232,6 +252,15 @@ namespace ResxTranslator.Windows
             this.tabPage1.Text = "Languages";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
+            // languageSettings1
+            // 
+            this.languageSettings1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.languageSettings1.Location = new System.Drawing.Point(0, 0);
+            this.languageSettings1.Margin = new System.Windows.Forms.Padding(0);
+            this.languageSettings1.Name = "languageSettings1";
+            this.languageSettings1.Size = new System.Drawing.Size(238, 123);
+            this.languageSettings1.TabIndex = 0;
+            // 
             // tabControl3
             // 
             this.tabControl3.Controls.Add(this.tabPageEditedResource);
@@ -252,6 +281,18 @@ namespace ResxTranslator.Windows
             this.tabPageEditedResource.TabIndex = 0;
             this.tabPageEditedResource.Text = "Resource editor";
             this.tabPageEditedResource.UseVisualStyleBackColor = true;
+            // 
+            // resourceGrid1
+            // 
+            this.resourceGrid1.CurrentResource = null;
+            this.resourceGrid1.CurrentSearch = null;
+            this.resourceGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resourceGrid1.Location = new System.Drawing.Point(0, 0);
+            this.resourceGrid1.Margin = new System.Windows.Forms.Padding(0);
+            this.resourceGrid1.Name = "resourceGrid1";
+            this.resourceGrid1.ShowNullValuesAsGrayed = false;
+            this.resourceGrid1.Size = new System.Drawing.Size(626, 439);
+            this.resourceGrid1.TabIndex = 0;
             // 
             // menuStripMain
             // 
@@ -445,7 +486,8 @@ namespace ResxTranslator.Windows
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem,
             this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem,
             this.openLastDirectoryOnProgramStartToolStripMenuItem,
-            this.displayNullValuesAsGrayedToolStripMenuItem});
+            this.displayNullValuesAsGrayedToolStripMenuItem,
+            this.setReferencePathsToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.settingsToolStripMenuItem.Text = "&Settings";
@@ -480,6 +522,19 @@ namespace ResxTranslator.Windows
             this.openLastDirectoryOnProgramStartToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
             this.openLastDirectoryOnProgramStartToolStripMenuItem.Text = "Open last directory on program start";
             // 
+            // displayNullValuesAsGrayedToolStripMenuItem
+            // 
+            this.displayNullValuesAsGrayedToolStripMenuItem.Name = "displayNullValuesAsGrayedToolStripMenuItem";
+            this.displayNullValuesAsGrayedToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
+            this.displayNullValuesAsGrayedToolStripMenuItem.Text = "Display values that will not be saved (null) as grayed";
+            // 
+            // setReferencePathsToolStripMenuItem
+            // 
+            this.setReferencePathsToolStripMenuItem.Name = "setReferencePathsToolStripMenuItem";
+            this.setReferencePathsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
+            this.setReferencePathsToolStripMenuItem.Text = "Set paths to referenced assemblies";
+            this.setReferencePathsToolStripMenuItem.Click += new System.EventHandler(this.setReferencePathsToolStripMenuItem_Click);
+            // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -511,51 +566,6 @@ namespace ResxTranslator.Windows
             this.aboutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
             this.aboutToolStripMenuItem.Text = "&About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
-            // 
-            // resourceTreeView1
-            // 
-            this.resourceTreeView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.resourceTreeView1.Location = new System.Drawing.Point(0, 0);
-            this.resourceTreeView1.Margin = new System.Windows.Forms.Padding(0);
-            this.resourceTreeView1.Name = "resourceTreeView1";
-            this.resourceTreeView1.Size = new System.Drawing.Size(238, 286);
-            this.resourceTreeView1.TabIndex = 0;
-            // 
-            // missingTranslationView1
-            // 
-            this.missingTranslationView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.missingTranslationView1.Location = new System.Drawing.Point(0, 0);
-            this.missingTranslationView1.Margin = new System.Windows.Forms.Padding(0);
-            this.missingTranslationView1.Name = "missingTranslationView1";
-            this.missingTranslationView1.ResourceLoader = null;
-            this.missingTranslationView1.Size = new System.Drawing.Size(238, 286);
-            this.missingTranslationView1.TabIndex = 0;
-            // 
-            // languageSettings1
-            // 
-            this.languageSettings1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.languageSettings1.Location = new System.Drawing.Point(0, 0);
-            this.languageSettings1.Margin = new System.Windows.Forms.Padding(0);
-            this.languageSettings1.Name = "languageSettings1";
-            this.languageSettings1.Size = new System.Drawing.Size(238, 123);
-            this.languageSettings1.TabIndex = 0;
-            // 
-            // resourceGrid1
-            // 
-            this.resourceGrid1.CurrentResource = null;
-            this.resourceGrid1.CurrentSearch = null;
-            this.resourceGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.resourceGrid1.Location = new System.Drawing.Point(0, 0);
-            this.resourceGrid1.Margin = new System.Windows.Forms.Padding(0);
-            this.resourceGrid1.Name = "resourceGrid1";
-            this.resourceGrid1.Size = new System.Drawing.Size(626, 439);
-            this.resourceGrid1.TabIndex = 0;
-            // 
-            // displayNullValuesAsGrayedToolStripMenuItem
-            // 
-            this.displayNullValuesAsGrayedToolStripMenuItem.Name = "displayNullValuesAsGrayedToolStripMenuItem";
-            this.displayNullValuesAsGrayedToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
-            this.displayNullValuesAsGrayedToolStripMenuItem.Text = "Display values that will not be saved (null) as grayed";
             // 
             // MainWindow
             // 
@@ -647,6 +657,7 @@ namespace ResxTranslator.Windows
         private SplitContainer splitContainer1;
         private ToolStripMenuItem markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem;
         private ToolStripMenuItem displayNullValuesAsGrayedToolStripMenuItem;
+        private ToolStripMenuItem setReferencePathsToolStripMenuItem;
     }
 }
 

--- a/src/Windows/MainWindow.Designer.cs
+++ b/src/Windows/MainWindow.Designer.cs
@@ -39,15 +39,11 @@ namespace ResxTranslator.Windows
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl2 = new System.Windows.Forms.TabControl();
             this.tabPage3 = new System.Windows.Forms.TabPage();
-            this.resourceTreeView1 = new ResxTranslator.Controls.ResourceTreeView();
             this.tabPage5 = new System.Windows.Forms.TabPage();
-            this.missingTranslationView1 = new ResxTranslator.Controls.MissingTranslationView();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.languageSettings1 = new ResxTranslator.Controls.LanguageSettings();
             this.tabControl3 = new System.Windows.Forms.TabControl();
             this.tabPageEditedResource = new System.Windows.Forms.TabPage();
-            this.resourceGrid1 = new ResxTranslator.Controls.ResourceGrid();
             this.menuStripMain = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -73,12 +69,17 @@ namespace ResxTranslator.Windows
             this.copyDefaultValuesOnLanguageAddToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ignoreEmptyResourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openLastDirectoryOnProgramStartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.licenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resourceTreeView1 = new ResxTranslator.Controls.ResourceTreeView();
+            this.missingTranslationView1 = new ResxTranslator.Controls.MissingTranslationView();
+            this.languageSettings1 = new ResxTranslator.Controls.LanguageSettings();
+            this.resourceGrid1 = new ResxTranslator.Controls.ResourceGrid();
+            this.displayNullValuesAsGrayedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.panelMain.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
@@ -199,15 +200,6 @@ namespace ResxTranslator.Windows
             this.tabPage3.Text = "All resources";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
-            // resourceTreeView1
-            // 
-            this.resourceTreeView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.resourceTreeView1.Location = new System.Drawing.Point(0, 0);
-            this.resourceTreeView1.Margin = new System.Windows.Forms.Padding(0);
-            this.resourceTreeView1.Name = "resourceTreeView1";
-            this.resourceTreeView1.Size = new System.Drawing.Size(238, 286);
-            this.resourceTreeView1.TabIndex = 0;
-            // 
             // tabPage5
             // 
             this.tabPage5.Controls.Add(this.missingTranslationView1);
@@ -218,16 +210,6 @@ namespace ResxTranslator.Windows
             this.tabPage5.TabIndex = 1;
             this.tabPage5.Text = "Missing translations";
             this.tabPage5.UseVisualStyleBackColor = true;
-            // 
-            // missingTranslationView1
-            // 
-            this.missingTranslationView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.missingTranslationView1.Location = new System.Drawing.Point(0, 0);
-            this.missingTranslationView1.Margin = new System.Windows.Forms.Padding(0);
-            this.missingTranslationView1.Name = "missingTranslationView1";
-            this.missingTranslationView1.ResourceLoader = null;
-            this.missingTranslationView1.Size = new System.Drawing.Size(238, 286);
-            this.missingTranslationView1.TabIndex = 0;
             // 
             // tabControl1
             // 
@@ -250,15 +232,6 @@ namespace ResxTranslator.Windows
             this.tabPage1.Text = "Languages";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
-            // languageSettings1
-            // 
-            this.languageSettings1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.languageSettings1.Location = new System.Drawing.Point(0, 0);
-            this.languageSettings1.Margin = new System.Windows.Forms.Padding(0);
-            this.languageSettings1.Name = "languageSettings1";
-            this.languageSettings1.Size = new System.Drawing.Size(238, 123);
-            this.languageSettings1.TabIndex = 0;
-            // 
             // tabControl3
             // 
             this.tabControl3.Controls.Add(this.tabPageEditedResource);
@@ -279,16 +252,6 @@ namespace ResxTranslator.Windows
             this.tabPageEditedResource.TabIndex = 0;
             this.tabPageEditedResource.Text = "Resource editor";
             this.tabPageEditedResource.UseVisualStyleBackColor = true;
-            // 
-            // resourceGrid1
-            // 
-            this.resourceGrid1.CurrentResource = null;
-            this.resourceGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.resourceGrid1.Location = new System.Drawing.Point(0, 0);
-            this.resourceGrid1.Margin = new System.Windows.Forms.Padding(0);
-            this.resourceGrid1.Name = "resourceGrid1";
-            this.resourceGrid1.Size = new System.Drawing.Size(626, 439);
-            this.resourceGrid1.TabIndex = 0;
             // 
             // menuStripMain
             // 
@@ -481,7 +444,8 @@ namespace ResxTranslator.Windows
             this.ignoreEmptyResourcesToolStripMenuItem,
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem,
             this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem,
-            this.openLastDirectoryOnProgramStartToolStripMenuItem});
+            this.openLastDirectoryOnProgramStartToolStripMenuItem,
+            this.displayNullValuesAsGrayedToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.settingsToolStripMenuItem.Text = "&Settings";
@@ -504,6 +468,12 @@ namespace ResxTranslator.Windows
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
             this.doNotShowResourcesWithoutAnyTranslationsToolStripMenuItem.Text = "Do not show resources with no translations";
             // 
+            // markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem
+            // 
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Name = "markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem";
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
+            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Text = "Mark as translatable only if the default value is in [ ] brackets";
+            // 
             // openLastDirectoryOnProgramStartToolStripMenuItem
             // 
             this.openLastDirectoryOnProgramStartToolStripMenuItem.Name = "openLastDirectoryOnProgramStartToolStripMenuItem";
@@ -524,29 +494,68 @@ namespace ResxTranslator.Windows
             // 
             this.helpToolStripMenuItem1.Image = global::ResxTranslator.Properties.Resources.Help;
             this.helpToolStripMenuItem1.Name = "helpToolStripMenuItem1";
-            this.helpToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
+            this.helpToolStripMenuItem1.Size = new System.Drawing.Size(139, 22);
             this.helpToolStripMenuItem1.Text = "&Help";
             this.helpToolStripMenuItem1.Click += new System.EventHandler(this.helpToolStripMenuItem1_Click);
             // 
             // licenceToolStripMenuItem
             // 
             this.licenceToolStripMenuItem.Name = "licenceToolStripMenuItem";
-            this.licenceToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.licenceToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
             this.licenceToolStripMenuItem.Text = "View licence";
             this.licenceToolStripMenuItem.Click += new System.EventHandler(this.licenceToolStripMenuItem_Click);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
             this.aboutToolStripMenuItem.Text = "&About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
-            // markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem
+            // resourceTreeView1
             // 
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Name = "markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem";
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
-            this.markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem.Text = "Mark as translatable only if the default value is in [ ] brackets";
+            this.resourceTreeView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resourceTreeView1.Location = new System.Drawing.Point(0, 0);
+            this.resourceTreeView1.Margin = new System.Windows.Forms.Padding(0);
+            this.resourceTreeView1.Name = "resourceTreeView1";
+            this.resourceTreeView1.Size = new System.Drawing.Size(238, 286);
+            this.resourceTreeView1.TabIndex = 0;
+            // 
+            // missingTranslationView1
+            // 
+            this.missingTranslationView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.missingTranslationView1.Location = new System.Drawing.Point(0, 0);
+            this.missingTranslationView1.Margin = new System.Windows.Forms.Padding(0);
+            this.missingTranslationView1.Name = "missingTranslationView1";
+            this.missingTranslationView1.ResourceLoader = null;
+            this.missingTranslationView1.Size = new System.Drawing.Size(238, 286);
+            this.missingTranslationView1.TabIndex = 0;
+            // 
+            // languageSettings1
+            // 
+            this.languageSettings1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.languageSettings1.Location = new System.Drawing.Point(0, 0);
+            this.languageSettings1.Margin = new System.Windows.Forms.Padding(0);
+            this.languageSettings1.Name = "languageSettings1";
+            this.languageSettings1.Size = new System.Drawing.Size(238, 123);
+            this.languageSettings1.TabIndex = 0;
+            // 
+            // resourceGrid1
+            // 
+            this.resourceGrid1.CurrentResource = null;
+            this.resourceGrid1.CurrentSearch = null;
+            this.resourceGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resourceGrid1.Location = new System.Drawing.Point(0, 0);
+            this.resourceGrid1.Margin = new System.Windows.Forms.Padding(0);
+            this.resourceGrid1.Name = "resourceGrid1";
+            this.resourceGrid1.Size = new System.Drawing.Size(626, 439);
+            this.resourceGrid1.TabIndex = 0;
+            // 
+            // displayNullValuesAsGrayedToolStripMenuItem
+            // 
+            this.displayNullValuesAsGrayedToolStripMenuItem.Name = "displayNullValuesAsGrayedToolStripMenuItem";
+            this.displayNullValuesAsGrayedToolStripMenuItem.Size = new System.Drawing.Size(391, 22);
+            this.displayNullValuesAsGrayedToolStripMenuItem.Text = "Display values that will not be saved (null) as grayed";
             // 
             // MainWindow
             // 
@@ -637,6 +646,7 @@ namespace ResxTranslator.Windows
         private ToolStripMenuItem licenceToolStripMenuItem;
         private SplitContainer splitContainer1;
         private ToolStripMenuItem markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem;
+        private ToolStripMenuItem displayNullValuesAsGrayedToolStripMenuItem;
     }
 }
 

--- a/src/Windows/MainWindow.cs
+++ b/src/Windows/MainWindow.cs
@@ -89,6 +89,7 @@ namespace ResxTranslator.Windows
             {
                 _currentSearch = value;
                 resourceTreeView1.ExecuteFindInNodes(value);
+                resourceGrid1.CurrentSearch = _currentSearch;
             }
         }
 

--- a/src/Windows/MainWindow.cs
+++ b/src/Windows/MainWindow.cs
@@ -71,11 +71,15 @@ namespace ResxTranslator.Windows
                 settings => settings.HideNontranslatedResources, this);
             Settings.Binder.BindControl(markToTranslateOnlyIfDefaultValueIsInBracketsToolStripMenuItem,
                 settings => settings.TranslatableInBrackets, this);
+            Settings.Binder.BindControl(displayNullValuesAsGrayedToolStripMenuItem,
+                settings => settings.ShowNullValuesAsGrayed, this);
 
             Settings.Binder.Subscribe((sender, args) => ResourceLoader.HideEmptyResources = args.NewValue,
                 settings => settings.HideEmptyResources, this);
             Settings.Binder.Subscribe((sender, args) => ResourceLoader.HideNontranslatedResources = args.NewValue,
                 settings => settings.HideNontranslatedResources, this);
+            Settings.Binder.Subscribe((sender, args) => resourceGrid1.ShowNullValuesAsGrayed = args.NewValue,
+                settings => settings.ShowNullValuesAsGrayed, this);
 
             Settings.Binder.SendUpdates(this);
 

--- a/src/Windows/MainWindow.cs
+++ b/src/Windows/MainWindow.cs
@@ -27,6 +27,8 @@ namespace ResxTranslator.Windows
 
             _defaultWindowTitle = $"{Text} {Assembly.GetAssembly(typeof(MainWindow)).GetName().Version.ToString(2)}";
 
+            LoadAssemblies(Settings.Default.ReferencePaths);
+
             ResourceLoader = new ResourceLoader();
             ResourceLoader.ResourceLoadProgress += OnResourceLoaderOnResourceLoadProgress;
             ResourceLoader.ResourcesChanged += OnResourceLoaderOnResourcesChanged;
@@ -133,6 +135,30 @@ namespace ResxTranslator.Windows
                 languageSettings1.RefreshLanguages(ResourceLoader.GetUsedLanguages(), true);
                 UpdateMenuStrip();
             });
+        }
+
+        private void LoadAssemblies(string[] paths)
+        {
+            if (paths == null)
+                return;
+
+            foreach (var path in paths)
+            {
+                var asms = AppDomain.CurrentDomain.GetAssemblies();
+
+                foreach (var filename in Directory.EnumerateFiles(path, "*.dll"))
+                {
+                    try
+                    {
+                        if (!asms.Any(x => x.Location == filename))
+                            Assembly.LoadFile(filename);
+                    }
+                    catch (NotSupportedException)
+                    {
+                        // Ignore
+                    }
+                }
+            }
         }
 
         private void UpdateMenuStrip()
@@ -421,6 +447,18 @@ namespace ResxTranslator.Windows
             Process.Start(Path.Combine(
                 Path.GetDirectoryName(Assembly.GetAssembly(typeof(MainWindow)).Location) ?? string.Empty,
                 "Licence.txt"));
+        }
+
+        private void setReferencePathsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            using (var form = new EditReferencePaths(Settings.Default.ReferencePaths))
+            {
+                form.ShowDialog();
+
+                Settings.Default.ReferencePaths = form.ReferencePaths;
+
+                LoadAssemblies(form.ReferencePaths);
+            }
         }
     }
 }

--- a/src/Windows/MainWindow.cs
+++ b/src/Windows/MainWindow.cs
@@ -451,14 +451,11 @@ namespace ResxTranslator.Windows
 
         private void setReferencePathsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            using (var form = new EditReferencePaths(Settings.Default.ReferencePaths))
-            {
-                form.ShowDialog();
+            var referencePaths = EditReferencePaths.ShowDialog(this, Settings.Default.ReferencePaths);
 
-                Settings.Default.ReferencePaths = form.ReferencePaths;
+            Settings.Default.ReferencePaths = referencePaths;
 
-                LoadAssemblies(form.ReferencePaths);
-            }
+            LoadAssemblies(referencePaths);
         }
     }
 }

--- a/src/app.config
+++ b/src/app.config
@@ -67,6 +67,9 @@
       <setting name="TranslatableInBrackets" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ShowNullValuesAsGrayed" serializeAs="String">
+        <value>False</value>
+      </setting>
     </ResxTranslator.Properties.Settings>
   </userSettings>
   <startup>

--- a/src/app.config
+++ b/src/app.config
@@ -70,6 +70,9 @@
       <setting name="ShowNullValuesAsGrayed" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ReferencePaths" serializeAs="String">
+        <value />
+      </setting>
     </ResxTranslator.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
Updated ResourceHolder to not save null values as empty strings. Currently if you save a resource it will save null values as empty strings. This is an issue because it prevents applications to default to the NoLanguageValue and will save all previous "missing" values as empty strings. With this I also added an option for cells to appear grayed when value is null to signify values that will not be saved.

Updated the project with option to set referenced assembly paths, this is required for saving resources with meta data that hold types from external assemblies - specifically ResXResourceReader will throw an exception on reader.GetMetadataEnumerator() when the assemblies are not loaded.

Updated ResXResourceReader with correct relative path for an issue with resx files that contain references to file resources (exception was thrown).

Added som quality of life functionality: search highlighting on cells and copy/paste/delete selection