### PR TITLE
Update English and Italian language files

### DIFF
--- a/src/Windows/AddResourceKeyWindow.it.resx
+++ b/src/Windows/AddResourceKeyWindow.it.resx
@@ -127,7 +127,7 @@
     <value>Nuova chiave</value>
   </data>
   <data name="textboxDefault.Text" xml:space="preserve">
-    <value>[MarcatorePostoTesto]</value>
+    <value>(MarcatorePostoTesto)</value>
   </data>
   <data name="labelDefaultValue.Text" xml:space="preserve">
     <value>Valori tradotti</value>

--- a/src/Windows/AddResourceKeyWindow.resx
+++ b/src/Windows/AddResourceKeyWindow.resx
@@ -229,7 +229,7 @@
     <value>1</value>
   </data>
   <data name="textboxDefault.Text" xml:space="preserve">
-    <value>[PlaceholderText]</value>
+    <value>(PlaceholderText)</value>
   </data>
   <data name="&gt;&gt;textboxDefault.Name" xml:space="preserve">
     <value>textboxDefault</value>

--- a/src/Windows/LanguageSelectDialog.resx
+++ b/src/Windows/LanguageSelectDialog.resx
@@ -129,7 +129,7 @@
     <value>1</value>
   </data>
   <data name="button1.Text" xml:space="preserve">
-    <value>Select</value>
+    <value>Add</value>
   </data>
   <data name="&gt;&gt;button1.Name" xml:space="preserve">
     <value>button1</value>
@@ -265,7 +265,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Select language...</value>
+    <value>Add language</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>LanguageSelectDialog</value>


### PR DESCRIPTION
@HakanL 

Fixed cosmetic error report [PlaceholderText] - changed in (Placeholdertext)

Fixed some strings regarding "Add language" window

Windows title "Add language" (as button command selecetd without ...)
"Add" button (instead "Select"). For me the action is to add a language.

Please made the same change about [Placeholdertext] also for Spanish language (src/Windows/AddResourceKeyWindow.es.resx).
